### PR TITLE
Render b with escaped format

### DIFF
--- a/src/Parser/Parts/CaptureType.cs
+++ b/src/Parser/Parts/CaptureType.cs
@@ -1,4 +1,4 @@
-namespace Parser
+namespace Parser.Parts
 {
     public enum CaptureType : byte
     {

--- a/src/Parser/Parts/Hole.cs
+++ b/src/Parser/Parts/Hole.cs
@@ -1,4 +1,4 @@
-namespace Parser
+namespace Parser.Parts
 {
     public struct Hole
     {

--- a/src/Parser/Parts/Literal.cs
+++ b/src/Parser/Parts/Literal.cs
@@ -1,4 +1,4 @@
-namespace Parser
+namespace Parser.Parts
 {
     public struct Literal
     {
@@ -6,7 +6,7 @@ namespace Parser
         /// <remarks>This can be 0 when the template starts with a hole or when there are multiple consecutive holes.</remarks>
         public ushort Print;
         /// <summary>Number of characters to skip in the original template at the current position.</summary>
-        /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</summary>
+        /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</remarks>
         public ushort Skip;
     }
 }

--- a/src/Parser/Template.cs
+++ b/src/Parser/Template.cs
@@ -187,7 +187,7 @@ namespace Parser
             sb.Append(',').Append(hole.Alignment);
           
         if (hole.Format != null)
-            sb.Append(':').Append(hole.Format);
+            sb.Append(':').Append(hole.Format.Replace("{","{{").Replace("}","}}"));
           
         sb.Append('}');
     }

--- a/src/Parser/Template.cs
+++ b/src/Parser/Template.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+using Parser.Parts;
 
 namespace Parser
 {
+  [SuppressMessage("ReSharper", "RedundantToStringCall", Justification = "Performance")]
   public class Template
   {
     /// <summary>The original template string.</summary>
@@ -147,7 +150,7 @@ namespace Parser
         }
     }
 
-    /// <summary>This is for testing only: recreates <see cref=Value /> from the parsed data.</summary>
+    /// <summary>This is for testing only: recreates <see cref="Value"/> from the parsed data.</summary>
     public string Rebuild()
     {
       var sb = new StringBuilder(Value.Length);

--- a/src/Parser/Template.cs
+++ b/src/Parser/Template.cs
@@ -186,8 +186,8 @@ namespace Parser
         if (hole.Alignment != 0)
             sb.Append(',').Append(hole.Alignment);
           
-        if (hole.Format != null)
-            sb.Append(':').Append(hole.Format.Replace("{","{{").Replace("}","}}"));
+        if (hole.Format != null) 
+            sb.Append(':').Append(hole.Format.Replace("{","{{").Replace("}","}}")); // rebuild of the escaped brackets in format
           
         sb.Append('}');
     }

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -112,20 +112,8 @@ namespace Parser
             int position;
             string name = ParseName(out position);
             int alignment = Peek() == ',' ? ParseAlignment() : 0;
-            string format;
-            if (Peek() == ':')
-            {
-                format = ParseFormat();
-            }
-            else
-            {
-                format = null;
-                //parseFormat does the skip
-                Skip('}');
-            }
-
-
-
+            string format = Peek() == ':' ? ParseFormat() : null;
+            Skip('}');
 
             AddLiteral(_position - start + (type == CaptureType.Normal ? 1 : 2));   // Account for skipped '{', '{$' or '{@'
             _holes.Add(new Hole
@@ -161,13 +149,16 @@ namespace Parser
         }
 
         /// <summary>
-        /// Parse format after hole name/index
+        /// Parse format after hole name/index. Don't read the last }
         /// </summary>
         /// <returns></returns>
         private string ParseFormat()
         {
+            
             Skip(':');
             var format = ParseFormatInner();
+            //unread the }
+            _position--;
             return format;
         }
 
@@ -193,8 +184,8 @@ namespace Parser
                         if (next == '}')
                         {
                             //this is an escaped } and need to be added to the format.
-                            Read();
-                            format += '}' + ParseFormatInner();
+                            Skip('}');
+                            format += "}" + ParseFormatInner();
                         }
                         else
                         {
@@ -210,8 +201,8 @@ namespace Parser
                         if (next == '{')
                         {
                             //this is an escaped } and need to be added to the format.
-                            Read();
-                            format += '{' + ParseFormatInner();
+                            Skip('{');
+                            format += "{" + ParseFormatInner();
                         }
                         else
                         {
@@ -221,7 +212,7 @@ namespace Parser
                         break;
                     }
             }
-            
+
             return format;
         }
 

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Parser.Parts;
 using static System.Diagnostics.Debug;
 
 namespace Parser
 {
+    [SuppressMessage("ReSharper", "FieldCanBeMadeReadOnly.Local", Justification = "Performance")]
     public class TemplateParser
     {
         public static Template Parse(string template)
@@ -101,7 +104,7 @@ namespace Parser
         {
             Skip('}');
             if (Read() != '}')
-                throw new TemplateParserException($"Unexpected '}}' ", _position - 2);
+                throw new TemplateParserException("Unexpected '}}' ", _position - 2);
             _literalLength++;
             AddLiteral();
         }
@@ -220,6 +223,7 @@ namespace Parser
 
         private char Read() => _template[_position++];
 
+        // ReSharper disable once UnusedParameter.Local
         private void Skip(char c)
         {
             // Can be out of bounds, but never in correct use (expects a required char).

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -170,16 +170,18 @@ namespace Parser
         {
             var format = ReadUntil(TextDelimiters);
             var c = Read();
-            if (_position == _length)
-            {
-                //end of template so done
-                return format;
-            }
+       
 
             switch (c)
             {
                 case '}':
                     {
+                        if (_position == _length)
+                        {
+                            //end of template so done
+                            return format;
+                        }
+
                         var next = Peek();
                         if (next == '}')
                         {

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -295,15 +295,15 @@ namespace Parser
             return negative ? -i : i;
         }
 
-        private string ReadUntil(char search, bool required = true)
-        {
-            int start = _position;
-            int i = _template.IndexOf(search, _position);
-            if (i == -1 && required)
-                throw new TemplateParserException($"Reached end of template while expecting '{search}'.", _position);
-            _position = i == -1 ? _length : i;
-            return _template.Substring(start, _position - start);
-        }
+        //private string ReadUntil(char search, bool required = true)
+        //{
+        //    int start = _position;
+        //    int i = _template.IndexOf(search, _position);
+        //    if (i == -1 && required)
+        //        throw new TemplateParserException($"Reached end of template while expecting '{search}'.", _position);
+        //    _position = i == -1 ? _length : i;
+        //    return _template.Substring(start, _position - start);
+        //}
 
         private string ReadUntil(char[] search, bool required = true)
         {

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -156,35 +156,16 @@ namespace Parser
         {
 
             Skip(':');
-            string format = null;
+            string format = ReadUntil(TextDelimiters); 
             while (true)
             {
-                if (format == null)
-                {
-                    //avoid string composition.
-                    format = ReadUntil(TextDelimiters);
-                }
-                else
-                {
-                    format += ReadUntil(TextDelimiters);
-                }
-
                 var c = Read();
 
                 switch (c)
                 {
                     case '}':
                         {
-                            if (_position == _length)
-                            {
-                                //unread the }
-                                _position--;
-                                //end of template so done
-                                return format;
-                            }
-
-                            var next = Peek();
-                            if (next == '}')
+                            if (_position < _length &&  Peek() == '}')
                             {
                                 //this is an escaped } and need to be added to the format.
                                 Skip('}');
@@ -192,7 +173,7 @@ namespace Parser
                             }
                             else
                             {
-                                //unread the }
+                                //done. unread the }
                                 _position--;
                                 //done
                                 return format;
@@ -218,6 +199,8 @@ namespace Parser
                             break;
                         }
                 }
+
+                format += ReadUntil(TextDelimiters);
             }
         }
 
@@ -292,16 +275,6 @@ namespace Parser
             SkipSpaces();
             return negative ? -i : i;
         }
-
-        //private string ReadUntil(char search, bool required = true)
-        //{
-        //    int start = _position;
-        //    int i = _template.IndexOf(search, _position);
-        //    if (i == -1 && required)
-        //        throw new TemplateParserException($"Reached end of template while expecting '{search}'.", _position);
-        //    _position = i == -1 ? _length : i;
-        //    return _template.Substring(start, _position - start);
-        //}
 
         private string ReadUntil(char[] search, bool required = true)
         {

--- a/src/Parser/TemplateParser.cs
+++ b/src/Parser/TemplateParser.cs
@@ -160,6 +160,10 @@ namespace Parser
             return ReadUntil(HoleDelimiters);
         }
 
+        /// <summary>
+        /// Parse format after hole name/index
+        /// </summary>
+        /// <returns></returns>
         private string ParseFormat()
         {
             Skip(':');
@@ -167,9 +171,12 @@ namespace Parser
             return format;
         }
 
+        /// <summary>
+        /// Parse inner of format, handle the escaped { and } in the format.
+        /// </summary>
+        /// <returns></returns>
         private string ParseFormatInner()
         {
-            // TODO: Escaped }} in formats?
             var format = ReadUntil(TextDelimiters);
             var c = Read();
             if (_position == _length)
@@ -214,8 +221,7 @@ namespace Parser
                         break;
                     }
             }
-
-
+            
             return format;
         }
 

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Parser.Parts;
 using Xunit;
 
 namespace Parser.Tests

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -173,6 +173,7 @@ namespace Parser.Tests
         [InlineData("{a,-2.0")]
         [InlineData("{a,:N0}")]
         [InlineData("{a,}")]        
+        [InlineData("{a,{}")]        
         public void ThrowsTemplateParserException(string input)
         {
             Assert.Throws<TemplateParserException>(() => TemplateParser.Parse(input));

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -174,7 +174,9 @@ namespace Parser.Tests
         [InlineData("{a,:N0}")]
         [InlineData("{a,}")]        
         [InlineData("{a,{}")]        
+        [InlineData("{a:{}")]        
         [InlineData("{a,d{e}")]        
+        [InlineData("{a:d{e}")]        
         public void ThrowsTemplateParserException(string input)
         {
             Assert.Throws<TemplateParserException>(() => TemplateParser.Parse(input));

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -174,6 +174,7 @@ namespace Parser.Tests
         [InlineData("{a,:N0}")]
         [InlineData("{a,}")]        
         [InlineData("{a,{}")]        
+        [InlineData("{a,d{e}")]        
         public void ThrowsTemplateParserException(string input)
         {
             Assert.Throws<TemplateParserException>(() => TemplateParser.Parse(input));

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -43,6 +43,8 @@ namespace Parser.Tests
         [InlineData(" {0,10} ")]
         [InlineData(" {0,-10} ")]
         [InlineData(" {0,-10:test} ")]
+        [InlineData("{{{0:d}}}")]
+        [InlineData("{{{0:0{{}")]
         public void ParseAndPrint(string input)
         {
             var template = TemplateParser.Parse(input);

--- a/test/Parser.Tests/ParserTests.cs
+++ b/test/Parser.Tests/ParserTests.cs
@@ -53,19 +53,21 @@ namespace Parser.Tests
         }
 
         [Theory]
-        [InlineData("{0}", 0)]
-        [InlineData("{001}", 1)]
-        [InlineData("{9}", 9)]
-        [InlineData("{1 }", 1)]
-        [InlineData("{1} {2}", 1)]
-        [InlineData("{@3} {$4}", 3)]
-        [InlineData("{3,6}", 3)]
-        [InlineData("{5:R}", 5)]        
-        public void ParsePositional(string input, int index)
+        [InlineData("{0}", 0, null)]
+        [InlineData("{001}", 1, null)]
+        [InlineData("{9}", 9, null)]
+        [InlineData("{1 }", 1, null)]
+        [InlineData("{1} {2}", 1, null)]
+        [InlineData("{@3} {$4}", 3, null)]
+        [InlineData("{3,6}", 3, null)]
+        [InlineData("{5:R}", 5, "R")]        
+        [InlineData("{0:0}", 0, "0")]        
+        public void ParsePositional(string input, int index, string format)
         {
             var template = TemplateParser.Parse(input);
 
             Assert.True(template.IsPositional);
+            Assert.Equal(format, template.Holes[0].Format);
             Assert.Equal(index, template.Holes[0].Index);
         }
 

--- a/test/Parser.Tests/RendererTests.cs
+++ b/test/Parser.Tests/RendererTests.cs
@@ -34,6 +34,10 @@ namespace Parser.Tests
         [InlineData(" completed tasks {tasks:l} in {time:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks parsing, testing, fixing in 010 sec")]
         [InlineData(" completed tasks {$tasks} in {time:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks \"System.String[]\" in 010 sec")]
         [InlineData(" completed tasks {0} in {1:000} sec", new object[] { new [] { "parsing", "testing", "fixing"}, 10 }, " completed tasks System.String[] in 010 sec")]
+        [InlineData("{{{0:d}}}", new object[] { 3 }, "{d}")] //format is here "d}" ... because escape from left-to-right 
+        [InlineData("{{{0:d} }}", new object[] { 3 }, "{3 }")]
+        [InlineData("{{{0:dd}}}", new object[] { 3 }, "{dd}")]
+        [InlineData("{{{0:0{{}", new object[] { 3 }, "{3{")] //format is here "0{"
         public void RenderTest(string input, object[] args, string expected)
         {
             var template = TemplateParser.Parse(input);            


### PR DESCRIPTION
extension of Render B

It works, but
- it uses string concat on format
- the rebuild of format is ugly 
