### PR TITLE
Cls-compliant & update AssemblyInfo

### DIFF
--- a/src/NLog.StructuredEvents/Parts/Literal.cs
+++ b/src/NLog.StructuredEvents/Parts/Literal.cs
@@ -7,9 +7,9 @@ namespace NLog.StructuredEvents.Parts
     {
         /// <summary>Number of characters from the original template to copy at the current position.</summary>
         /// <remarks>This can be 0 when the template starts with a hole or when there are multiple consecutive holes.</remarks>
-        public ushort Print;
+        public short Print;
         /// <summary>Number of characters to skip in the original template at the current position.</summary>
         /// <remarks>0 is a special value that mean: 1 escaped char, no hole. It can also happen last when the template ends with a literal.</remarks>
-        public ushort Skip;
+        public short Skip;
     }
 }

--- a/src/NLog.StructuredEvents/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredEvents/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -15,6 +16,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 //not sure if working
 [assembly: InternalsVisibleTo("NLog.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100ef8eab4fbdeb511eeb475e1659fe53f00ec1c1340700f1aa347bf3438455d71993b28b1efbed44c8d97a989e0cb6f01bcb5e78f0b055d311546f63de0a969e04cf04450f43834db9f909e566545a67e42822036860075a1576e90e1c43d43e023a24c22a427f85592ae56cac26f13b7ec2625cbc01f9490d60f16cfbb1bc34d9")]

--- a/src/NLog.StructuredEvents/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredEvents/Properties/AssemblyInfo.cs
@@ -6,11 +6,13 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
+[assembly: AssemblyTitle("Parser and renderer for structured log events")]
+[assembly: AssemblyCopyright("Copyright (c) 2016-2017 Julian Verdurmen")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Parser")]
+[assembly: AssemblyProduct("NLog.StructuredEvents")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("0.1.0.0")]
+//[assembly: AssemblyVersion("1.0.0.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/NLog.StructuredEvents/TemplateParser.cs
+++ b/src/NLog.StructuredEvents/TemplateParser.cs
@@ -49,7 +49,7 @@ namespace NLog.StructuredEvents
         /// - at the end of the template.</summary>
         private void AddLiteral(int skip = 0)
         {
-            _literals.Add(new Literal { Print = (ushort)_literalLength, Skip = (ushort)skip });
+            _literals.Add(new Literal { Print = (short)_literalLength, Skip = (short)skip });
             _literalLength = 0;
         }
 

--- a/src/NLog.StructuredEvents/project.json
+++ b/src/NLog.StructuredEvents/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Parsing and rendering message templates",
   "authors": [ "Julian Verdurmen" ],
   "packOptions": {
@@ -12,7 +12,8 @@
     "repository": {
       "type": "git",
       "url": "git://github.com/NLog/NLog.StructuredEvents"
-    }
+    },
+    "releaseNotes": "CLSCompliant (breaking change in Literal properties)"
 
   },
 

--- a/test/NLog.StructuredEvents.Tests/project.json
+++ b/test/NLog.StructuredEvents.Tests/project.json
@@ -3,7 +3,7 @@
   "testRunner": "xunit",
   "dependencies": {
     "xunit": "2.2.0-beta2-build3300",
-    "NLog.StructuredEvents": "0.3-*",
+    "NLog.StructuredEvents": "*",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Newtonsoft.Json": "9.0.1"
   },


### PR DESCRIPTION
Fixes https://github.com/NLog/NLog.StructuredEvents/issues/44
Fixes CLS-issue for NLog 4.5 (see https://github.com/NLog/NLog/pull/1951)